### PR TITLE
Fix hardcoded /dashboard/ URL

### DIFF
--- a/django_sql_dashboard/templates/django_sql_dashboard/saved_dashboard.html
+++ b/django_sql_dashboard/templates/django_sql_dashboard/saved_dashboard.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-{% if user_can_execute_sql %}<p><a href="/dashboard/">Dashboard index</a></p>{% endif %}
+{% if user_can_execute_sql %}<p><a href="{% url 'django_sql_dashboard-index' %}">Dashboard index</a></p>{% endif %}
 <h1>{% if dashboard.title %}{{ dashboard.title }}{% else %}{{ dashboard.slug }}{% endif %}</h1>
 {% if dashboard.description %}
   <p>{{ dashboard.description }}</p>


### PR DESCRIPTION
Closes #99
Use `{% url 'django_sql_dashboard-index' %}` instead.