### PR TITLE
Make owned_by an autocomplete field in the Django admin.

### DIFF
--- a/django_sql_dashboard/admin.py
+++ b/django_sql_dashboard/admin.py
@@ -39,6 +39,7 @@ class DashboardAdmin(admin.ModelAdmin):
             {"fields": ("view_policy", "edit_policy", "view_group", "edit_group")},
         ),
     )
+    autocomplete_fields = ["owned_by"]
 
     def view_dashboard(self, obj):
         return mark_safe(


### PR DESCRIPTION
Currently the `owned_by` field lists a user primary key:

> ![image](https://user-images.githubusercontent.com/124687/119490760-3546ae00-bd2b-11eb-8877-1e19fd6a5201.png)

Changing this requires the admin user to click the magnifying glass, at which point a new popup opens which allows them to search for users.

In contrast, this PR changes the field to be defined via [`ModelAdmin.autocomplete_fields`](https://docs.djangoproject.com/en/3.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.autocomplete_fields) so it's a bit easier to change:

> ![image](https://user-images.githubusercontent.com/124687/119490931-60c99880-bd2b-11eb-8b2f-7f4a40650750.png)

That said, I'm now realizing that one downside of this approach is that there's no way to get more information about the selected user.  With the other approach, clicking on "varma" takes you to the Django change view for that user, so that if you have any doubts, it's easy to see who the record is really pointing at.  So I won't be offended if you decide to close this PR without merging!