### PR TITLE
Only show editable dashboards in admin changelist view.

### DIFF
--- a/django_sql_dashboard/admin.py
+++ b/django_sql_dashboard/admin.py
@@ -62,3 +62,10 @@ class DashboardAdmin(admin.ModelAdmin):
         if not request.user.is_superuser:
             readonly_fields.append("owned_by")
         return readonly_fields
+
+    def get_queryset(self, request):
+        if request.user.is_superuser:
+            # Superusers should be able to see all dashboards.
+            return super().get_queryset(request)
+        # Otherwise, show only the dashboards the user has edit access to.
+        return Dashboard.get_editable_by_user(request.user)

--- a/django_sql_dashboard/models.py
+++ b/django_sql_dashboard/models.py
@@ -104,6 +104,21 @@ class Dashboard(models.Model):
         return False
 
     @classmethod
+    def get_editable_by_user(cls, user):
+        allowed_policies = [cls.EditPolicies.LOGGEDIN]
+        if user.is_staff:
+            allowed_policies.append(cls.EditPolicies.STAFF)
+        if user.is_superuser:
+            allowed_policies.append(cls.EditPolicies.SUPERUSER)
+        return (
+            cls.objects.filter(
+                models.Q(owned_by=user)
+                | models.Q(edit_policy__in=allowed_policies)
+                | models.Q(view_policy=cls.EditPolicies.GROUP, edit_group__user=user)
+            )
+        ).distinct()
+
+    @classmethod
     def get_visible_to_user(cls, user):
         allowed_policies = [cls.ViewPolicies.PUBLIC, cls.ViewPolicies.LOGGEDIN]
         if user.is_staff:


### PR DESCRIPTION
This attempts to fix #130 by only listing dashboards that are editable by the user in the Dashboard change list view.

Note that this means that the user will _not_ see viewable-but-not-editable dashboards in the change list view!  I originally tried making this possible, but simply not linking to the change view if a user couldn't edit it, but I couldn't figure out how to do this using the Django admin.