### PR TITLE
Fix issue with Postgres 10

### DIFF
--- a/django_sql_dashboard/views.py
+++ b/django_sql_dashboard/views.py
@@ -159,7 +159,7 @@ def _dashboard_index(
             )
             select
               information_schema.columns.table_name,
-              array_to_json(array_agg(column_name order by ordinal_position)) as columns
+              array_to_json(array_agg(cast(column_name as text) order by ordinal_position)) as columns
             from
               information_schema.columns
             join

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,7 +3,7 @@
 To contribute to this library, first checkout the code. Then create a new virtual environment:
 
     cd django-sql-dashboard
-    python -mvenv venv
+    python -m venv venv
     source venv/bin/activate
 
 Or if you are using `pipenv`:


### PR DESCRIPTION
When using version 1.0 on Ubuntu 18.04 with Postgres 10.17 an Internal Server (500) error is generated. 

I traced this back to the change made for version 1.0 on line 162 (see compared diff [here](https://github.com/simonw/django-sql-dashboard/compare/acb3752..b8835))

The `array_agg` will throw the error

```
could not find array type for data type information_schema.sql_identifier
```

casting the `column_name` field to text resolves this issue for Postgres 10. 

I did run the tests locally and 88 passed with 2 warnings. The warnings were:

```
test_project/test_utils.py::test_apply_sort[select * from (select * from foo) as results order by "bar"-bar-True-select * from (select * from foo) as results order by "bar" desc]
  /Users/ryan/github/django-sql-dashboard/venv/lib/python3.9/site-packages/django/db/backends/postgresql/base.py:304: RuntimeWarning: Normally Django will use a connection to the 'postgres' database to avoid running initialization queries against the production database when it's not needed (for example, when running tests). Django was unable to create a connection to the 'postgres' database and will use the first PostgreSQL database instead.
    warnings.warn(

test_project/test_utils.py::test_apply_sort[select * from (select * from foo) as results order by "bar"-bar-True-select * from (select * from foo) as results order by "bar" desc]
  /Users/ryan/github/django-sql-dashboard:0: PytestWarning: Error when trying to teardown test databases: RuntimeError("generator didn't stop after throw()")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```