### PR TITLE
Allow saved dashboards to be exported by users with execute_sql permission

### DIFF
--- a/django_sql_dashboard/templates/django_sql_dashboard/widgets/default.html
+++ b/django_sql_dashboard/templates/django_sql_dashboard/widgets/default.html
@@ -13,7 +13,7 @@
   {% if result.truncated %}
     <p class="results-truncated">
       Results were truncated
-      {% if user_can_export_data and not saved_dashboard %}
+      {% if user_can_export_data %}
         <input
           class="btn"
           style="font-size: 0.6rem"
@@ -64,7 +64,7 @@
   </table>
   <details style="margin-top: 1em;"><summary style="font-size: 0.7em; margin-bottom: 0.5em; cursor: pointer;">Copy and export data</summary>
     <textarea id="copyable-{{ result.index }}" style="height: 10em">{{ result|sql_dashboard_tsv }}</textarea>
-    {% if user_can_export_data and not saved_dashboard %}
+    {% if user_can_export_data %}
       <div class="export-buttons">
         <input
           class="btn"
@@ -83,6 +83,44 @@
   </details>
   <p>Duration: {{ result.duration_ms|floatformat:2 }}ms</p>
   <!-- templates considered: {{ result.templates|join:", " }} -->
+
+  {% if saved_dashboard and user_can_export_data %}
+  {% comment %}
+    This is a bit of a hack to allow users with execute_sql permission to export
+    saved dashboards. We're essentially simulating a user who typed a SQL
+    query into the dashboard index page and decided to export it.
+  {% endcomment %}
+  <template id="export-template-{{ result.index}}">
+    <form action="{% url 'django_sql_dashboard-index' %}" method="POST" hidden>
+      {% csrf_token %}
+      <input type="hidden" name="sql" value="{{ result.sql }}">
+    </form>
+  </template>
+  <script>
+  (function() {
+    var exportButtons = document.querySelectorAll("input[name^=export_]");
+    var template = document.querySelector("#export-template-{{ result.index }}");
+    var formTemplate = template.content.querySelector('form');
+    Array.from(exportButtons).forEach(button => {
+      var exportType = button.name.match(/^export_(.+)_/)[1];
+
+      button.addEventListener("click", e => {
+        e.preventDefault();
+        var form = formTemplate.cloneNode(true);
+        var exportEl = document.createElement('input');
+        exportEl.type = "hidden";
+        exportEl.name = 'export_' + exportType + '_0';
+        exportEl.value = button.value;
+        form.appendChild(exportEl);
+        document.body.appendChild(form);
+        form.submit();
+        document.body.removeChild(form);
+      });
+    });
+  })();
+  </script>
+  {% endif %}
+
   <script>
   (function() {
     var ta = document.querySelector("#copyable-{{ result.index }}");

--- a/test_project/test_export.py
+++ b/test_project/test_export.py
@@ -10,14 +10,14 @@ def test_export_requires_setting(admin_client, dashboard_db):
         assert response.status_code == 403
 
 
-def test_no_export_on_saved_dashboard(
+def test_export_on_saved_dashboard(
     admin_client, dashboard_db, settings, saved_dashboard
 ):
     settings.DASHBOARD_ENABLE_FULL_EXPORT = True
     response = admin_client.get("/dashboard/test/")
     assert response.status_code == 200
     assert b'<pre class="sql">select 22 + 55</pre>' in response.content
-    assert b"Export all as CSV" not in response.content
+    assert b"Export all as CSV" in response.content
 
 
 def test_export_csv(admin_client, dashboard_db, settings):


### PR DESCRIPTION
This fixes #133, but in a funky way.

Originally, I thought this would be fairly straightforward: I started by simply removing the conditions for hiding the export buttons if the user was on a saved dashboard page, and move on from there.

However, I quickly noticed that saved dashboard pages use a GET form, while dashboard index pages (the ones with custom SQL and fully exportable queries) use a POST form.  It seemed like it might be a security hazard to allow for a GET request to potentially hold up the server for really long queries--I was imagining a CSRF that initiated a denial of service attack on a dashboard site, and though I'm not 100% sure it's possible, I wanted to play it safe--so I decided not to go the GET route.

I then learned that submit buttons actually support a [`formmethod` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit#formmethod) which would allow the export buttons to convert the request to a POST if they were clicked, but then I faced the problem of embedding the CSRF token in the form only on POST requests (I didn't want it to be included in GET requests because that would make the URLs look gross).  All of this led me down a bit of a rabbit hole and I started worrying about how much new logic this whole endeavor would introduce to the back-end, some of which might potentially accidentally introduce new security holes.

Then I thought of a weird solution: what if I didn't add _any_ new logic to the backend, and instead made the export buttons trigger some JS on the client-side that simply simulated a user entering an SQL query in the dashboard index page and exporting it?  It turns out that this _can_ be simulated via a properly constructed form, so that's what this PR does right now.  As a result, my (possibly flawed) belief is that it _can't_ introduce any new security holes in the back-end, because it _only_ makes changes to the front-end.

Anyways, it's also possibly too clever for its own good, and could be brittle.  And one major limitation is that **it doesn't currently support dashboards with named parameters**, though I don't think adding support for that would be hard.  But I figured I'd submit what I've got so far and see what you think before moving forward, @simonw.
