### PR TITLE
Refactor named parameters feature to allow extensibility

### DIFF
--- a/django_sql_dashboard/templates/django_sql_dashboard/_parameters.html
+++ b/django_sql_dashboard/templates/django_sql_dashboard/_parameters.html
@@ -2,8 +2,7 @@
 <h3>Query parameters</h3>
 <div class="query-parameters">
 {% for param in parameters %}
-  <label for="qp{{ forloop.counter }}">{{ param.name }}</label>
-  <input type="text" id="qp{{ forloop.counter }}" name="{{ param.name }}" value="{{ param.value }}">
+  {{ param.form_control }}
 {% endfor %}
 </div>
 <input

--- a/django_sql_dashboard/templates/django_sql_dashboard/_parameters.html
+++ b/django_sql_dashboard/templates/django_sql_dashboard/_parameters.html
@@ -1,0 +1,14 @@
+{% if parameters %}
+<h3>Query parameters</h3>
+<div class="query-parameters">
+{% for param in parameters %}
+  <label for="qp{{ forloop.counter }}">{{ param.name }}</label>
+  <input type="text" id="qp{{ forloop.counter }}" name="{{ param.name }}" value="{{ param.value }}">
+{% endfor %}
+</div>
+<input
+  class="btn"
+  type="submit"
+  value="Run quer{% if query_results|length > 1 %}ies{% else %}y{% endif %}"
+/>
+{% endif %}

--- a/django_sql_dashboard/templates/django_sql_dashboard/dashboard.html
+++ b/django_sql_dashboard/templates/django_sql_dashboard/dashboard.html
@@ -28,20 +28,7 @@
   {% if query_results %}
     <p>↓ <a href="#save-dashboard">Save this dashboard</a> | <a href="{{ request.path }}">Remove all queries</a></p>
   {% endif %}
-  {% if parameter_values %}
-    <h3>Query parameters</h3>
-    <div class="query-parameters">
-    {% for name, value in parameter_values %}
-        <label for="qp{{ forloop.counter }}">{{ name }}</label>
-        <input type="text" id="qp{{ forloop.counter }}" name="{{ name }}" value="{{ value }}">
-    {% endfor %}
-    </div>
-    <input
-      class="btn"
-      type="submit"
-      value="Run quer{% if query_results|length > 1 %}ies{% else %}y{% endif %}"
-    />
-  {% endif %}
+  {% include "django_sql_dashboard/_parameters.html" %}
   {% for result in query_results %}
     {% include result.templates with result=result %}
   {% endfor %}

--- a/django_sql_dashboard/templates/django_sql_dashboard/saved_dashboard.html
+++ b/django_sql_dashboard/templates/django_sql_dashboard/saved_dashboard.html
@@ -30,20 +30,7 @@
 </p>
 
 <form action="{{ request.path }}" method="GET">
-  {% if parameter_values %}
-    <h3>Query parameters</h3>
-    <div class="query-parameters">
-    {% for name, value in parameter_values %}
-        <label for="qp{{ forloop.counter }}">{{ name }}</label>
-        <input type="text" id="qp{{ forloop.counter }}" name="{{ name }}" value="{{ value }}">
-    {% endfor %}
-    </div>
-    <input
-      class="btn"
-      type="submit"
-      value="Run quer{% if query_results|length > 1 %}ies{% else %}y{% endif %}"
-    />
-  {% endif %}
+  {% include "django_sql_dashboard/_parameters.html" %}
   {% for result in query_results %}
     {% include result.templates with result=result %}
   {% endfor %}

--- a/django_sql_dashboard/utils.py
+++ b/django_sql_dashboard/utils.py
@@ -141,10 +141,13 @@ class Parameter:
 
     @classmethod
     def extract(cls, sql: str, value_sources: list[dict[str, str]], target: list=[]):
-        new_params = [cls(*found) for found in cls.extract_re.findall(sql)]
+        for found in cls.extract_re.findall(sql):
+            # Ensure 'found' is an iterable of capturing groups, even if there is only one capturing group in the regex
+            if isinstance(found, str):
+                found = [found]
+            new_param = cls(*found)
 
-        # Ensure parameters are added only once
-        for new_param in new_params:
+            # Ensure parameters are added only once
             previous_param = next((param for param in target if param.name == new_param.name), None)
             if previous_param:
                 new_param.ensure_consistency(previous_param)

--- a/django_sql_dashboard/utils.py
+++ b/django_sql_dashboard/utils.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 
 from django.core import signing
 from django.conf import settings
+from django.utils.safestring import mark_safe
 
 SQL_SALT = "django_sql_dashboard:query"
 
@@ -120,7 +121,11 @@ class Parameter:
     @value.setter
     def value(self, new_value):
         self._value = new_value if new_value != "" else self.default_value
-    
+
+    def form_control(self):
+        return mark_safe(f"""<label for="qp_{self.name}">{self.name}</label>
+<input type="text" id="qp_{self.name}" name="{self.name}" value="{self.value if self.value is not None else ""}">""")
+
     @classmethod
     def extract(cls, sql: str, value_sources: list[dict[str, str]], target: list=[]):
         new_params = [cls(name) for (name) in cls.extract_re.findall(sql)]

--- a/django_sql_dashboard/utils.py
+++ b/django_sql_dashboard/utils.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 
 from django.core import signing
 from django.conf import settings
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 SQL_SALT = "django_sql_dashboard:query"
@@ -136,8 +137,8 @@ class Parameter:
         self._value = self.get_sanitized(new_value) if new_value != "" else self.default_value
    
     def form_control(self):
-        return mark_safe(f"""<label for="qp_{self.name}">{self.name}</label>
-<input type="text" id="qp_{self.name}" name="{self.name}" value="{self.value if self.value is not None else ""}">""")
+        return mark_safe(f"""<label for="qp_{escape(self.name)}">{escape(self.name)}</label>
+<input type="text" id="qp_{escape(self.name)}" name="{escape(self.name)}" value="{escape(self.value) if self.value is not None else ""}">""")
 
     @classmethod
     def extract(cls, sql: str, value_sources: list[dict[str, str]], target: list=[]):

--- a/django_sql_dashboard/views.py
+++ b/django_sql_dashboard/views.py
@@ -300,12 +300,12 @@ def _dashboard_index(
     if dashboard and dashboard.title:
         html_title = dashboard.title
 
-    # Add named parameter values, if any exist
+    # Add named parameter values to the page title, when they are distinct from the default values
     provided_values = {
-        key: value for key, value in parameter_values.items() if value.strip()
+        param.name: param.value for param in parameters if param.value != param.default_value
     }
     if provided_values:
-        if len(provided_values) == 1:
+        if len(parameters) == 1:
             html_title += ": {}".format(list(provided_values.values())[0])
         else:
             html_title += ": {}".format(

--- a/django_sql_dashboard/views.py
+++ b/django_sql_dashboard/views.py
@@ -25,7 +25,7 @@ from .utils import (
     apply_sort,
     check_for_base64_upgrade,
     displayable_rows,
-    extract_named_parameters,
+    PARAMETER_CLASS,
     postgresql_reserved_words,
     sign_sql,
     unsign_sql,
@@ -192,10 +192,7 @@ def _dashboard_index(
     sql_query_parameter_errors = []
     for sql in sql_queries:
         try:
-            extracted = extract_named_parameters(sql)
-            for p in extracted:
-                if p not in parameters:
-                    parameters.append(p)
+            PARAMETER_CLASS.extract(sql, value_sources=[request.POST, request.GET], target=parameters)
             sql_query_parameter_errors.append(False)
         except ValueError as e:
             if "%" in sql:
@@ -205,9 +202,9 @@ def _dashboard_index(
             else:
                 sql_query_parameter_errors.append(str(e))
     parameter_values = {
-        parameter: request.POST.get(parameter, request.GET.get(parameter, ""))
+        parameter.name: parameter.value
         for parameter in parameters
-        if parameter != "sql"
+        if parameter.name != "sql"
     }
     extra_qs = "&{}".format(urlencode(parameter_values)) if parameter_values else ""
     results_index = -1
@@ -250,7 +247,7 @@ def _dashboard_index(
                     # Running a SELECT prevents future SET TRANSACTION READ WRITE:
                     cursor.execute("SELECT 1;")
                     cursor.fetchall()
-                    cursor.execute(sql, parameter_values)
+                    PARAMETER_CLASS.execute(cursor, sql, parameters)
                     try:
                         rows = list(cursor.fetchmany(row_limit + 1))
                     except ProgrammingError as e:
@@ -343,7 +340,7 @@ def _dashboard_index(
         "user_can_execute_sql": user_can_execute_sql,
         "user_can_export_data": getattr(settings, "DASHBOARD_ENABLE_FULL_EXPORT", None)
         and user_can_execute_sql,
-        "parameter_values": parameter_values.items(),
+        "parameters": parameters,
         "too_long_so_use_post": too_long_so_use_post,
         "saved_dashboards": saved_dashboards,
     }
@@ -410,10 +407,7 @@ def export_sql_results(request):
     assert format in ("csv", "tsv")
     sqls = request.POST.getlist("sql")
     sql = sqls[int(sql_index)]
-    parameter_values = {
-        parameter: request.POST.get(parameter, "")
-        for parameter in extract_named_parameters(sql)
-    }
+    parameters = PARAMETER_CLASS.extract(sql, value_sources=[request.POST])
     alias = getattr(settings, "DASHBOARD_DB_ALIAS", "dashboard")
     # Decide on filename
     sql_hash = hashlib.sha256(sql.encode("utf-8")).hexdigest()[:6]
@@ -443,7 +437,7 @@ def export_sql_results(request):
 
     def rows():
         try:
-            cursor.execute(sql, parameter_values)
+            PARAMETER_CLASS.execute(cursor, sql, parameters)
             done_header = False
             while True:
                 records = cursor.fetchmany(size=2000)

--- a/test_project/test_parameters.py
+++ b/test_project/test_parameters.py
@@ -26,12 +26,12 @@ def test_parameter_form(admin_client, dashboard_db):
     html = response.content.decode("utf-8")
     # Form should have three form fields
     for fragment in (
-        '<label for="qp1">foo</label>',
-        '<input type="text" id="qp1" name="foo" value="">',
-        '<label for="qp2">bar</label>',
-        '<input type="text" id="qp2" name="bar" value="">',
-        '<label for="qp3">baz</label>',
-        '<input type="text" id="qp3" name="baz" value="">',
+        '<label for="qp_foo">foo</label>',
+        '<input type="text" id="qp_foo" name="foo" value="">',
+        '<label for="qp_bar">bar</label>',
+        '<input type="text" id="qp_bar" name="bar" value="">',
+        '<label for="qp_baz">baz</label>',
+        '<input type="text" id="qp_baz" name="baz" value="">',
     ):
         assert fragment in html
 


### PR DESCRIPTION
Refactor parsing of (and access to) named parameters into a single extensible [`Parameter`](https://github.com/simonw/django-sql-dashboard/compare/main...ipamo:parameter-class?expand=1#diff-49b2ed4bea433f772ce7a9c5ea6bbb9512ff633f0bf5885edbe8e3e0a715b456R110) class. The feature remains the same but the implementation is cleaner.

In addition, the actual `Parameter` class used by the library may be changed using a setting named `DASHBOARD_PARAMETER_CLASS`. This allows users of the library to implement custom parameter parsings without changing the default behaviour of the libary.

See issue #149 for extension ideas (`%(value)d`, `%(flag:true)b`, etc).

Note: I changed the `id` of the `input` HTML fields (from numerical `qpX` to `qp_{parameterName}`) so that these fields may be generated directly from instances of the `Parameter` class.

All tests pass.
