### PR TITLE
Update to python3.12, django4.2 and psycopg3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 WORKDIR /app
 

--- a/django_sql_dashboard/views.py
+++ b/django_sql_dashboard/views.py
@@ -17,9 +17,6 @@ from django.http.response import (
     StreamingHttpResponse,
 )
 from django.shortcuts import get_object_or_404, render
-from django.utils.safestring import mark_safe
-
-from psycopg2.extensions import quote_ident
 
 from .models import Dashboard
 from .utils import (

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -p pytest_use_postgresql
+addopts = -p pytest_plugins.pytest_use_postgresql
 DJANGO_SETTINGS_MODULE = config.settings
 site_dirs = test_project/

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,11 @@ setup(
             "templatetags/*.py",
         ]
     },
-    install_requires=["Django>=3.0", "markdown", "bleach"],
+    install_requires=["Django>=4.2", "markdown", "bleach"],
     extras_require={
         "test": [
             "black>=22.3.0",
-            "psycopg2",
+            "psycopg>=3.0",
             "pytest",
             "pytest-django==4.2.0",
             "pytest-pythonpath",
@@ -52,5 +52,5 @@ setup(
         ],
     },
     tests_require=["django-sql-dashboard[test]"],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
## why

1. Django 4.2 introduced support for psycopg3 and also a deprecation note:  `Support for psycopg2 is likely to be deprecated and removed at some point in the future.` (https://django.readthedocs.io/en/latest/releases/4.2.html#psycopg-3-support)
2. Users of `django-sql-dashboard` trying to update to psycopg3 will get a module not found error caused by the following import in `views.py`:
```python
from psycopg2.extensions import quote_ident
```
(which is also unused, I think :smile:)
## what this PR aims to improve
* `addopts` in `pytest.ini`: When I ran the tests for the first time (in docker) there was a problem with the import of `pytest_use_postgresql` so I've modify it.
* Python version update to 3.12 in Docker.
* The test packages: Django >= 4.2, psycopg >= 3.0, required python >= 3.8 (check https://www.psycopg.org/psycopg3/docs/basic/install.html#supported-systems).
* Deleted unused imports from `views.py`.

#### Thanks for this repo!