### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,4 @@ multi_line_output = 3
 skip = '.git*'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+ignore-words-list = 'ths'

--- a/test_project/test_dashboard_permissions.py
+++ b/test_project/test_dashboard_permissions.py
@@ -324,7 +324,7 @@ def test_user_can_edit(
         assert can_edit_using_admin == expected
         if can_edit_using_admin:
             # Check that they cannot edit the SQL queries, because they do not
-            # have the execute_sql permisssion
+            # have the execute_sql permission
             assert not user.has_perm("django_sql_dashboard.execute_sql")
             html = get_admin_change_form_html(client, user, dashboard_obj)
             soup = BeautifulSoup(html, "html5lib")


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Feel ok to ignore/close