### PR TITLE
Remove unused psycopg2.extensions.quote_ident import

### DIFF
--- a/django_sql_dashboard/views.py
+++ b/django_sql_dashboard/views.py
@@ -19,8 +19,6 @@ from django.http.response import (
 from django.shortcuts import get_object_or_404, render
 from django.utils.safestring import mark_safe
 
-from psycopg2.extensions import quote_ident
-
 from .models import Dashboard
 from .utils import (
     apply_sort,


### PR DESCRIPTION
## Summary

Remove the unused `from psycopg2.extensions import quote_ident` import from `views.py`.

This import was never used anywhere in the codebase (grep confirms it only appears on line 22 as the import statement), but it prevents the package from working with psycopg3, which is now the recommended PostgreSQL adapter for Django (since Django 4.2).

## Test plan

- [x] Confirmed `quote_ident` is not used anywhere in the codebase
- [x] Tested with psycopg3 - package loads and works correctly

Fixes #162